### PR TITLE
Fix strange attribute behaviour

### DIFF
--- a/Sources/RichEditorSwiftUI/BaseFoundation/RichTextCoordinator.swift
+++ b/Sources/RichEditorSwiftUI/BaseFoundation/RichTextCoordinator.swift
@@ -150,6 +150,7 @@ open class RichTextCoordinator: NSObject {
     }
 
     open func textViewDidChangeSelection(_ notification: Notification) {
+        replaceCurrentAttributesIfNeeded()
         context.onTextViewEvent(
             .didChangeSelection(
                 selectedRange: textView.selectedRange,
@@ -272,6 +273,19 @@ extension RichTextCoordinator {
         if textView.hasSelectedRange { return }
         let attributes = textView.richTextAttributes
         textView.setRichTextAttributes(attributes)
+#endif
+    }
+
+    /**
+     On macOS, we have to update the typingAttributes when we
+     move the text input cursor and there's no selected text.
+     So that the current attributes will set again for updated location.
+     */
+    func replaceCurrentAttributesIfNeeded() {
+#if macOS
+        if textView.hasSelectedRange { return }
+        let attributes = textView.richTextAttributes
+        textView.setNewRichTextAttributes(attributes)
 #endif
     }
 }

--- a/Sources/RichEditorSwiftUI/Components/RichTextViewComponent+Attributes.swift
+++ b/Sources/RichEditorSwiftUI/Components/RichTextViewComponent+Attributes.swift
@@ -51,5 +51,11 @@ public extension RichTextViewComponent {
             setRichTextAttribute(attribute, to: value)
         }
     }
+
+    func setNewRichTextAttributes(
+        _ attributes: RichTextAttributes
+    ) {
+        typingAttributes = attributes
+    }
 }
 


### PR DESCRIPTION
# Changelog

Fix attributes of previous selection was kept even we move courser to new location.

## Breaking Changes

- Attributes are remained from previous location and not shown in toolbar as active style

## Bug Fixes

- Fixed some attributes are not removed when we select new location.
